### PR TITLE
Verbosity mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ sgrnable -t data/Fasta_Files/GFP.fasta -g data/Fasta_Files/E_coli_MG1655_genome.
 
 ## Contact
 
-Need something? Send me an email at Raghuvanshi.Siddarth@gmail.com or avery.noonan@ubc.ca
+Need something? Send me an email at Raghuvanshi.Siddarth@gmail.com
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ What things you need to install the software and how to install them
 
 ### Installation Guide
 
-Prior to installation,it is best practise to create a new enviroment to store the program and dependencies locally. This setup will create an conda environment with the name sgRNAble and install all required dependencies. Start this process by navigating to the path of the github download(inside the folder). 
+Prior to installation,it is best practise to create a new enviroment to store the program and dependencies locally. This setup will create an conda environment with the name sgRNAble and install all required dependencies. Start this process by navigating to the path of the github download(inside the folder).
 
 ```
 cd PATH/TO/sgRNAble
@@ -48,8 +48,14 @@ sgrnable -t data/Fasta_Files/GFP.fasta -g data/Fasta_Files/E_coli_MG1655_genome.
 ## Authors
 * [Siddarth Raghuvanshi](https://github.com/Siddarth-Raghuvanshi)
 * [Ahmed Abdelmoneim](https://github.com/AhmedAbdelmoneim)
-* Avery Noonan
+* [Avery Noonan](https://github.com/Noonanav)
 
 ## Contact
 
-Need something? Send me an email at Raghuvanshi.Siddarth@gmail.com
+Need something? Send me an email at Raghuvanshi.Siddarth@gmail.com or avery.noonan@ubc.ca
+
+## References
+
+Farasat, I., & Salis, H. M. (2016). A Biophysical Model of CRISPR/Cas9 Activity for Rational Design of Genome Editing and Gene          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Regulation. _PLOS Computational Biology_, 12(1), e1004724. doi:10.1371/journal.pcbi.1004724
+
+Doench, J. G., Fusi, N., Sullender, M., Hegde, M., Vaimberg, E. W., Donovan, K. F., . . . Root, D. E. (2016). Optimized sgRNA design to &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximize activity and minimize off-target effects of CRISPR-Cas9. _Nature biotechnology_, 34, 184. doi:10.1038/nbt.3437

--- a/README.md
+++ b/README.md
@@ -56,6 +56,6 @@ Need something? Send me an email at Raghuvanshi.Siddarth@gmail.com or avery.noon
 
 ## References
 
-Farasat, I., & Salis, H. M. (2016). A Biophysical Model of CRISPR/Cas9 Activity for Rational Design of Genome Editing and Gene          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Regulation. _PLOS Computational Biology_, 12(1), e1004724. doi:10.1371/journal.pcbi.1004724
+Farasat, I., & Salis, H. M. (2016). A Biophysical Model of CRISPR/Cas9 Activity for Rational Design of Genome Editing and Gene          Regulation. _PLOS Computational Biology_, 12(1), e1004724. doi:10.1371/journal.pcbi.1004724
 
-Doench, J. G., Fusi, N., Sullender, M., Hegde, M., Vaimberg, E. W., Donovan, K. F., . . . Root, D. E. (2016). Optimized sgRNA design to &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximize activity and minimize off-target effects of CRISPR-Cas9. _Nature biotechnology_, 34, 184. doi:10.1038/nbt.3437
+Doench, J. G., Fusi, N., Sullender, M., Hegde, M., Vaimberg, E. W., Donovan, K. F., . . . Root, D. E. (2016). Optimized sgRNA design to maximize activity and minimize off-target effects of CRISPR-Cas9. _Nature biotechnology_, 34, 184. doi:10.1038/nbt.3437

--- a/optimal_guide_finder/cas_model.py
+++ b/optimal_guide_finder/cas_model.py
@@ -133,7 +133,7 @@ class CasModel():
             mers_omitted_tally += target_list_output[1]
             genome_dictionary[filename][full_pam] = target_sequence_list
 
-        logger.error(str(str(mers_omitted_tally) + ' k-mers with non-nucleotide characters omitted from hashtable'))
+        logger.error(str(str(mers_omitted_tally) + ' k-mers with non-nucleotide characters omitted from target list'))
 
         self.genome_dictionary = genome_dictionary
 

--- a/optimal_guide_finder/cas_model.py
+++ b/optimal_guide_finder/cas_model.py
@@ -146,7 +146,7 @@ class CasModel():
             [folat] -- delta G value
         """
         dg = 0
-        for i in range(len(cr_rna)): 
+        for i in range(len(cr_rna)):
             pos = 20 - i # TODO: magic number
             if cr_rna[i] == target_seq[i]:
                 continue
@@ -196,13 +196,15 @@ class CasModel():
 
         counter = 0
 
+        non_nucleotide_count = [] # Added
         while counter < (len(full_sequence)-length):
             word = full_sequence[counter: counter+length]
             try:
                 positions_at_mers[word].append(counter+length)
             except:
-                logger.error('Genome sequence contains non-nucleotide character')
+                non_nucleotide_count.append(['Genome sequence contains non-nucleotide character'])
             counter += 1
+        logger.error(str(str(len(non_nucleotide_count)) + ' non-nucleotide characters identified'))
 
         return positions_at_mers
 

--- a/optimal_guide_finder/guide_finder.py
+++ b/optimal_guide_finder/guide_finder.py
@@ -23,8 +23,8 @@ def init_parser():
         ArgumentParser -- parser ready to accept arguments
     """
     # Parser to get the files listed in the arguments
-    parser = argparse.ArgumentParser(description="""This program helps you to find all possible guide RNAs that will 
-                                       target the gene. Then using the model created by Salis Lab, 
+    parser = argparse.ArgumentParser(description="""This program helps you to find all possible guide RNAs that will
+                                       target the gene. Then using the model created by Salis Lab,
                                        you can see the off target effects for the each possible guide.""",
                                      formatter_class=argparse.RawTextHelpFormatter)
 
@@ -34,7 +34,7 @@ def init_parser():
     parser.add_argument("-g", "--genome_sequence", required=True, nargs='+',
                         help="""The Genome of the organism, if targeting a plasmid, make sure to \n
                               include it as well (Fasta or Genebank)""")
-    parser.add_argument("-a", "--azimuth_cutoff", type=int, required=False, 
+    parser.add_argument("-a", "--azimuth_cutoff", type=int, required=False,
                         default=10, help="""How many guides should pass from azimuth screening,
                               the guides are passed based on descending azimuth prediction score""")
     parser.add_argument("-o", "--output_path", required=False, default="output",
@@ -60,7 +60,7 @@ def get_sequence(args):
         args.target_sequence, "fasta"))
 
     for name in target_dict:
-        target_dict[name] = target_dict[name].seq.ungap(gap="N").upper()
+        target_dict[name] = target_dict[name].seq.upper()
 
     # Reads the Genome files using biopython and combines them into one genome object
     genome = SeqRecord(Seq(""))
@@ -68,9 +68,9 @@ def get_sequence(args):
         genome_parts = SeqIO.parse(args.genome_sequence[i], "fasta")
         for part in genome_parts:
             if args.copy_number == 1:
-                genome.seq = genome.seq + part.seq.ungap(gap="N")
+                genome.seq = genome.seq + part.seq
             else:
-                genome.seq = genome.seq + part.seq.ungap(gap="N") * int(args.copy_number[i])
+                genome.seq = genome.seq + part.seq * int(args.copy_number[i])
 
     return target_dict, genome.seq.upper()
 

--- a/optimal_guide_finder/guide_generator.py
+++ b/optimal_guide_finder/guide_generator.py
@@ -4,6 +4,7 @@ Module for generating list of potentail guides
 import numpy as np
 from Bio.Seq import Seq
 from optimal_guide_finder.Azimuth_Model import model_comparison
+from tqdm import tqdm
 
 PAM = "GG"
 GUIDE_RNA_LENGTH = 20

--- a/optimal_guide_finder/guide_strength_calculator.py
+++ b/optimal_guide_finder/guide_strength_calculator.py
@@ -3,6 +3,7 @@ import time
 from multiprocessing import Process, Queue, Pool
 import numpy as np
 import pandas as pd
+from tqdm import tqdm
 from optimal_guide_finder.cas_model import CasModel
 import logging
 logger = logging.getLogger(__name__)
@@ -29,7 +30,7 @@ def initalize_model(guide_info, filename, num_threads=None):
 
     pool = Pool(processes=num_threads)
     results = []
-    for gene in guide_info:
+    for gene in tqdm(guide_info):
         for i, guide in enumerate(guide_info[gene][0]):
             guide_data = pd.Series([guide, gene, guide_info[gene][1][i], guide_info[gene][2][i]],
                                    index=["Guide Sequence", "Gene/ORF Name", "Location in Gene", "Strand"])

--- a/optimal_guide_finder/guide_strength_calculator.py
+++ b/optimal_guide_finder/guide_strength_calculator.py
@@ -30,7 +30,7 @@ def initalize_model(guide_info, filename, num_threads=None):
 
     pool = Pool(processes=num_threads)
     results = []
-    for gene in tqdm(guide_info):
+    for gene in guide_info:
         for i, guide in enumerate(guide_info[gene][0]):
             guide_data = pd.Series([guide, gene, guide_info[gene][1][i], guide_info[gene][2][i]],
                                    index=["Guide Sequence", "Gene/ORF Name", "Location in Gene", "Strand"])

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name="sgRNAble_mod",
+    name="sgRNAble",
     version="0.0.1",
     author="Avery Noonan, Siddarth Raghuvanshi, Ahmed Abdelmoneim",
     author_email="sidr97@gmail.com",
@@ -20,7 +20,7 @@ setuptools.setup(
     ],
     python_requires='>=3.6',
     entry_points={
-        "console_scripts": ['sgrnable_mod = optimal_guide_finder.guide_finder:main']
+        "console_scripts": ['sgrnable = optimal_guide_finder.guide_finder:main']
     },
     install_requires=[
         'matplotlib==3.2.1',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name="sgRNAble",
+    name="sgRNAble_mod",
     version="0.0.1",
     author="Avery Noonan, Siddarth Raghuvanshi, Ahmed Abdelmoneim",
     author_email="sidr97@gmail.com",
@@ -20,7 +20,7 @@ setuptools.setup(
     ],
     python_requires='>=3.6',
     entry_points={
-        "console_scripts": ['sgrnable = optimal_guide_finder.guide_finder:main']
+        "console_scripts": ['sgrnable_mod = optimal_guide_finder.guide_finder:main']
     },
     install_requires=[
         'matplotlib==3.2.1',


### PR DESCRIPTION
Changes relate primarily to verbosity:

- Tally k-mers containing non-nucleotide k-mers (when initially creating dictionary and when making target list)
- Adding tqdm to a single for loop (since functions are called multiple times, I haven't found the best for loop to encompass a significant portion of guide processing, and contain a reasonable # of iterations [>1])

Also to handling of non-nucleotide characters:

- I reverted previous commits using `ungap(gap='N')` to remove Ns (I'd rather lose some real targets than create targets that don't exist)
- pulled k-mers from `target_sequence_list` in `_identify_target_sequences_matching_pam()`

README.md:

- added references